### PR TITLE
fix: assume optionExample to be null or undefined

### DIFF
--- a/src/issueConverter.ts
+++ b/src/issueConverter.ts
@@ -26,7 +26,7 @@ export class IssueConverter {
 
   private contentBody(name: string): string {
     const rule = this.rules.find((el) =>  el.ruleName === name);
-    const examplesString = rule.optionExamples.reduce((agg: string, ex: string) => {
+    const examplesString = (rule.optionExamples || []).reduce((agg: string, ex: string) => {
       return agg + '\n' + '```' + ex + '```';
     }, '');
     const schemaString = rule.options != null ? `


### PR DESCRIPTION
According to the `IRuleMetadata` definition https://github.com/palantir/tslint/blob/master/src/language/rule/rule.ts, `optionExamples` property could be null, which should be handled properly