### PR TITLE
feat: introduce handlebar for markdown rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ src/*.js.map
 test/*.js
 test/*.js.map
 node_modules
-npm-debug.log
 coverage
+docs/rules.json

--- a/body-template.md.hbs
+++ b/body-template.md.hbs
@@ -1,0 +1,39 @@
+# Rule: {{{rule.ruleName}}}
+
+{{{rule.description}}}{{#if rule.descriptionDetails }}
+
+{{{rule.descriptionDetails}}}
+{{/if}}
+{{#if rule.rationale }}
+
+##### Rationale
+
+{{{ rule.rationale }}}
+{{/if}}
+{{ notesHeader rule }}
+{{#if rule.typescriptOnly }}- **TypeScript Only**
+{{/if}}{{#if rule.hasFix }}- **Has Fix**
+{{/if}}{{#if rule.requiresTypeInfo }}- **Requires Type Info**
+{{/if}}
+
+{{#if rule.optionsDescription }}
+### Config
+
+{{{ rule.optionsDescription }}}
+{{/if}}
+{{#if rule.optionExamples }}
+
+##### Examples
+
+{{#each rule.optionExamples }}
+{{{json . false}}}
+{{/each}}
+{{/if}}
+
+{{#if rule.options }}
+##### Schema
+
+{{{json rule.options true }}}
+{{/if}}
+
+For more information see [this page](https://palantir.github.io/tslint/rules/{{{rule.ruleName}}}).

--- a/package.json
+++ b/package.json
@@ -59,7 +59,9 @@
     "typescript": "^2.2.2"
   },
   "dependencies": {
+    "@types/handlebars": "^4.0.32",
     "autobind-decorator": "^1.3.4",
+    "handlebars": "^4.0.6",
     "lodash": "^4.17.4",
     "rxjs": "^5.3.0",
     "tslint": "5.0.0"

--- a/src/contentRenderer.ts
+++ b/src/contentRenderer.ts
@@ -1,0 +1,31 @@
+'use strict';
+
+import * as path from 'path';
+import * as fs from 'fs';
+import * as handlebars from 'handlebars';
+import {IRuleMetadata} from 'tslint';
+import autobind = require('autobind-decorator');
+
+handlebars.registerHelper('notesHeader', (rule: IRuleMetadata) => {
+  return (rule.typescriptOnly || rule.hasFix || rule.requiresTypeInfo) ? `\n##### Notes\n` : '';
+});
+handlebars.registerHelper('json', (obj: any, escape: boolean = false) => {
+  const json = escape ? JSON.stringify(obj, null, 2) : obj;
+  return '```json\n' + json + '\n```';
+});
+
+@autobind
+export class ContentRenderer {
+  static templateFileName: string = 'body-template.md.hbs';
+
+  readonly template: string;
+
+  constructor(public templatePath: string) {
+    const templateFile = path.join(templatePath, ContentRenderer.templateFileName);
+    this.template = fs.readFileSync(templateFile).toString('UTF-8');
+  }
+
+  render(rule: IRuleMetadata): string {
+    return handlebars.compile(this.template)({rule});
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,10 +6,11 @@ import {IRuleMetadata} from 'tslint';
 import {IConfig} from './codeclimateDefinitions';
 
 const configPath: string = '/config.json';
-const basePath: string = '/code/';
+const targetPath: string = '/code/';
+const linterPath: string = '/usr/src/app/';
 const rulesPath: string = '../docs/rules';
 
-const config: IConfig = loadCodeClimateConfig(configPath);
+const codeClimateConfig: IConfig = loadCodeClimateConfig(configPath);
 const rules: IRuleMetadata[] = require(rulesPath);
 
 function loadCodeClimateConfig(file: string): IConfig {
@@ -21,11 +22,12 @@ function loadCodeClimateConfig(file: string): IConfig {
   }
 }
 
-const tsLinter: TsLinter = new TsLinter(
-  basePath,
-  config,
+const tsLinter: TsLinter = new TsLinter({
+  targetPath,
+  linterPath,
+  codeClimateConfig,
   rules
-);
+});
 
 tsLinter
   .lint()

--- a/src/test/contentRenderer.spec.ts
+++ b/src/test/contentRenderer.spec.ts
@@ -1,0 +1,101 @@
+'use strict';
+
+const assert = require('power-assert');
+import {IRuleMetadata} from 'tslint';
+import {ContentRenderer} from '../contentRenderer';
+
+describe('ContentRenderer', () => {
+  describe('.render(name: string, rule: IRuleMetadata)', () => {
+    it('renders markdown with full information from rule metadata', done => {
+      // Given
+      const renderer = new ContentRenderer('./');
+      const rule: IRuleMetadata = {
+        ruleName: 'foo-rule',
+        type: 'style',
+        description: 'DESCRIPTION',
+        descriptionDetails: 'DETAILS',
+        hasFix: true,
+        optionsDescription: '`true`',
+        options: {
+          type: 'array',
+          items: {
+            type: 'string',
+            enum: [ 'yes', 'no' ]
+          }
+        },
+        optionExamples: [
+          'true', 'false'
+        ],
+        rationale: 'RATIONALE',
+        requiresTypeInfo: true,
+        typescriptOnly: true
+      };
+      const optionExamples = rule.optionExamples.map(o => '```json\n' + o + '\n```').join('\n');
+      const options = '```json\n' + JSON.stringify(rule.options, null, 2) + '\n```';
+      const expected = `# Rule: ${rule.ruleName}
+
+${rule.description}
+
+${rule.descriptionDetails}
+
+##### Rationale
+
+${rule.rationale}
+
+##### Notes
+
+- **TypeScript Only**
+- **Has Fix**
+- **Requires Type Info**
+
+### Config
+
+${rule.optionsDescription}
+
+##### Examples
+
+${optionExamples}
+
+##### Schema
+
+${options}
+
+For more information see [this page](https://palantir.github.io/tslint/rules/${rule.ruleName}).`;
+      // When
+      const actual = renderer.render(rule);
+      // Then
+      assert.equal(actual, expected);
+      done();
+    });
+    it('renders markdown with least information from rule metadata', done => {
+      // Given
+      const renderer = new ContentRenderer('./');
+      const rule: IRuleMetadata = {
+        ruleName: 'foo-rule',
+        type: 'style',
+        description: 'DESCRIPTION',
+        optionsDescription: '`true`',
+        options: { },
+        typescriptOnly: false
+      };
+      const options = '```json\n' + JSON.stringify(rule.options, null, 2) + '\n```';
+      const expected = `# Rule: ${rule.ruleName}
+
+${rule.description}
+
+### Config
+
+${rule.optionsDescription}
+
+##### Schema
+
+${options}
+
+For more information see [this page](https://palantir.github.io/tslint/rules/${rule.ruleName}).`;
+      // When
+      const actual = renderer.render(rule);
+      // Then
+      done();
+    });
+  });
+});

--- a/src/test/issueConverter.spec.ts
+++ b/src/test/issueConverter.spec.ts
@@ -3,13 +3,17 @@
 const assert = require('power-assert');
 import * as sinon from 'sinon';
 import * as ts from 'typescript';
-import { RuleFailure, IRuleMetadata } from 'tslint';
-import { IssueConverter } from '../issueConverter';
+import {IRuleMetadata, RuleFailure} from 'tslint';
+import {IssueConverter} from '../issueConverter';
 import * as CodeClimate from '../codeclimateDefinitions';
+import {IConfig} from '../codeclimateDefinitions';
 
 describe('IssueConverter', () => {
   it('.convert(failure: RuleFailure)', () => {
     // given
+    const linterPath: string = './';
+    const targetPath: string = '/base/path/';
+    const codeClimateConfig: IConfig = {include_paths: []};
     const failure = 'Style failed';
     const ruleName = 'foo-rule';
     const ruleMetadata: IRuleMetadata = {
@@ -23,10 +27,10 @@ describe('IssueConverter', () => {
         'foo', 'bar'
       ]
     };
-    const converter = new IssueConverter('/code/', [ruleMetadata]);
+    const converter = new IssueConverter({ targetPath, linterPath, codeClimateConfig, rules: [ruleMetadata] });
     const sourceFile = sinon.mock({}) as any as ts.SourceFile;
     const sourcePath = 'path/target-source-file.ts';
-    sourceFile.fileName = `/code/${sourcePath}`;
+    sourceFile.fileName = `${targetPath}${sourcePath}`;
     sourceFile.getLineAndCharacterOfPosition = (pos: number) => {
         return pos === 1 ? { line: 2, character: 30 } : { line: 8, character: 24 };
     };

--- a/src/tsLinterOption.ts
+++ b/src/tsLinterOption.ts
@@ -1,0 +1,10 @@
+'use strict';
+import {IConfig} from './codeclimateDefinitions';
+import {IRuleMetadata} from 'tslint';
+
+export interface ITsLinterOption {
+  targetPath: string;
+  linterPath: string;
+  codeClimateConfig: IConfig;
+  rules: IRuleMetadata[];
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,6 +17,10 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/handlebars@^4.0.32":
+  version "4.0.32"
+  resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.0.32.tgz#637e8d945a9354aab47df7125005490fe9f8e592"
+
 "@types/lodash@^4.14.62":
   version "4.14.62"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.62.tgz#8674f9861582148a60b7a89cb260f11378d11683"
@@ -591,7 +595,7 @@ gulplog@^1.0.0:
   dependencies:
     glogg "^1.0.0"
 
-handlebars@^4.0.1:
+handlebars@^4.0.1, handlebars@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.6.tgz#2ce4484850537f9c97a8026d5399b935c4ed4ed7"
   dependencies:


### PR DESCRIPTION
This PR is to close #16.  Now output would look like [tslint's document counterpart](https://palantir.github.io/tslint/rules/member-ordering/):

## output

```json
{
  "type": "issue",
  "check_name": "member-ordering",
  "content": {
    "body": "# Rule: member-ordering\n\nEnforces member ordering.\n##### Rationale\n\nA consistent ordering for class members can make classes easier to read, navigate, and edit.\n\n##### Notes\n\n- **TypeScript Only**\n\n### Config\n\n\nOne argument, which is an object, must be provided. It should contain an `order` property.\nThe `order` property should have a value of one of the following strings:\n\n* `fields-first`\n* `instance-sandwich`\n* `statics-first`\n\nAlternatively, the value for `order` maybe be an array consisting of the following strings:\n\n* `public-static-field`\n* `public-static-method`\n* `protected-static-field`\n* `protected-static-method`\n* `private-static-field`\n* `private-static-method`\n* `public-instance-field`\n* `protected-instance-field`\n* `private-instance-field`\n* `public-constructor`\n* `protected-constructor`\n* `private-constructor`\n* `public-instance-method`\n* `protected-instance-method`\n* `private-instance-method`\n\nYou can also omit the access modifier to refer to \"public-\", \"protected-\", and \"private-\" all at once; for example, \"static-field\".\n\nYou can also make your own categories by using an object instead of a string:\n\n    {\n        \"name\": \"static non-private\",\n        \"kinds\": [\n            \"public-static-field\",\n            \"protected-static-field\",\n            \"public-static-method\",\n            \"protected-static-method\"\n        ]\n    }\n\nThe 'alphabetize' option will enforce that members within the same category should be alphabetically sorted by name.\n\n##### Examples\n\n```json\n[true, { \"order\": \"fields-first\" }]\n```\n```json\n\n[true, {\n    \"order\": [\n        \"static-field\",\n        \"instance-field\",\n        \"constructor\",\n        \"public-instance-method\",\n        \"protected-instance-method\",\n        \"private-instance-method\"\n    ]\n}]\n```\n```json\n\n[true, {\n    \"order\": [\n        {\n            \"name\": \"static non-private\",\n            \"kinds\": [\n                \"public-static-field\",\n                \"protected-static-field\",\n                \"public-static-method\",\n                \"protected-static-method\"\n            ]\n        },\n        \"constructor\"\n    ]\n}]\n```\n\n##### Schema\n\n```json\n{\n  \"type\": \"object\",\n  \"properties\": {\n    \"order\": {\n      \"oneOf\": [\n        {\n          \"type\": \"string\",\n          \"enum\": [\n            \"fields-first\",\n            \"instance-sandwich\",\n            \"statics-first\"\n          ]\n        },\n        {\n          \"type\": \"array\",\n          \"items\": {\n            \"type\": \"string\",\n            \"enum\": [\n              \"public-static-field\",\n              \"public-static-method\",\n              \"protected-static-field\",\n              \"protected-static-method\",\n              \"private-static-field\",\n              \"private-static-method\",\n              \"public-instance-field\",\n              \"protected-instance-field\",\n              \"private-instance-field\",\n              \"public-constructor\",\n              \"protected-constructor\",\n              \"private-constructor\",\n              \"public-instance-method\",\n              \"protected-instance-method\",\n              \"private-instance-method\"\n            ]\n          },\n          \"maxLength\": 13\n        }\n      ]\n    }\n  },\n  \"additionalProperties\": false\n}\n```\n\nFor more information see [this page](https://palantir.github.io/tslint/rules/member-ordering)."
  },
  "description": "Declaration of protected instance method not allowed after declaration of private instance method. Instead, this should come after public instance methods.",
  "categories": [
    "Style"
  ],
  "remediation_points": 50000,
  "location": {
    "path": "src/tsLinter.ts",
    "positions": {
      "begin": {
        "line": 65,
        "column": 3
      },
      "end": {
        "line": 67,
        "column": 4
      }
    }
  }
}
```

## markdown will be rendered as

![screen shot 0029-04-09 at 17 04 03](https://cloud.githubusercontent.com/assets/1194760/24835803/ad6cfdb4-1d46-11e7-9610-f9e632e167b5.png)
