### PR TITLE
Nail down node module versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,10 +63,10 @@
     "handlebars": "^4.0.6",
     "lodash": "^4.17.4",
     "rxjs": "^5.3.0",
-    "tslint": "5.0.0",
-    "tslint-config-airbnb": "^5.0.0",
-    "tslint-config-standard": "^5.0.2",
-    "tslint-eslint-rules": "^4.0.0",
-    "tslint-react": "^3.0.0"
+    "tslint": "5.1.0",
+    "tslint-config-airbnb": "5.0.0",
+    "tslint-config-standard": "5.0.2",
+    "tslint-eslint-rules": "4.0.0",
+    "tslint-react": "3.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2139,7 +2139,7 @@ tslib@^1.0.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.6.0.tgz#cf36c93e02ae86a20fc131eae511162b869a6652"
 
-tslint-config-airbnb@^5.0.0:
+tslint-config-airbnb@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/tslint-config-airbnb/-/tslint-config-airbnb-5.0.0.tgz#edd7602da2a825c4cfe50d25873a5c53eb1d9f55"
   dependencies:
@@ -2147,13 +2147,13 @@ tslint-config-airbnb@^5.0.0:
     tslint-microsoft-contrib "^5.0.0"
     vrsource-tslint-rules "^5.1.0"
 
-tslint-config-standard@^5.0.2:
+tslint-config-standard@5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/tslint-config-standard/-/tslint-config-standard-5.0.2.tgz#e98fd5c412a6b973798366dc2c85508cf0ed740f"
   dependencies:
     tslint-eslint-rules "^4.0.0"
 
-tslint-eslint-rules@^4.0.0:
+tslint-eslint-rules@4.0.0, tslint-eslint-rules@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/tslint-eslint-rules/-/tslint-eslint-rules-4.0.0.tgz#4e0e59ecd5701c9a48c66ed47bdcafb1c635d27b"
   dependencies:
@@ -2165,25 +2165,11 @@ tslint-microsoft-contrib@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.0.0.tgz#0ff6389ce3dbc5ea103782900a7806fffa1450ff"
 
-tslint-react@^3.0.0:
+tslint-react@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/tslint-react/-/tslint-react-3.0.0.tgz#00c48ab7f22e91533b62bdef2c162b49447af00a"
 
-tslint@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.0.0.tgz#ad3b7952f8a9b21079248bee01c2eaf92167e185"
-  dependencies:
-    babel-code-frame "^6.22.0"
-    colors "^1.1.2"
-    diff "^3.2.0"
-    findup-sync "~0.3.0"
-    glob "^7.1.1"
-    optimist "~0.6.0"
-    resolve "^1.3.2"
-    semver "^5.3.0"
-    tsutils "^1.4.0"
-
-tslint@~5.1.0:
+tslint@5.1.0, tslint@~5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.1.0.tgz#51a47baeeb58956fcd617bd2cf00e2ef0eea2ed9"
   dependencies:
@@ -2197,7 +2183,7 @@ tslint@~5.1.0:
     semver "^5.3.0"
     tsutils "^1.4.0"
 
-tsutils@^1.4.0:
+tsutils@1.6.0, tsutils@^1.4.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.6.0.tgz#1fd7fac2a61369ed99cd3997f0fbb437128850f2"
 


### PR DESCRIPTION
There was an issue with the peer deps of the various tslint configs. This PR nails down all of the versions so none are upgraded accidentally. 