### PR TITLE
Fix Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,7 @@ COPY ./bin/ ./bin/
 RUN npm install --global yarn && \
   apk --update add git jq && \
   yarn install && \
-  jq <engine.json ".version = \"$(bin/version tslint)\"" > /tmp/engine.json && \
-  mv {/tmp/,}engine.json && \
+  jq <engine.json ".version = \"$(bin/version tslint)\"" > /engine.json && \
   bin/get-tslint-rules && \
   chown -R app:app . && \
   apk del --purge git jq && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,13 @@ LABEL maintainer "Kyle Holzinger <kylelholzinger@gmail.com>"
 
 WORKDIR /usr/src/app
 
-# For cache purpose
-ARG VER_TSLINT=5.0.0
-
 COPY engine.json ./
 COPY ./bin/ ./bin/
 
 RUN npm install --global yarn && \
   apk --update add git jq && \
-  bin/get-tslint-rules "$VER_TSLINT" && \
-  cat engine.json | jq ".version = \"$VER_TSLINT\"" > /tmp/engine.json && \
+  bin/get-tslint-rules "$(bin/version tslint)" && \
+  cat engine.json | jq ".version = \"$(bin/version tslint)\"" > /tmp/engine.json && \
   apk del --purge git jq && \
   npm uninstall --global yarn
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,29 @@
 FROM mhart/alpine-node:6
 LABEL maintainer "Kyle Holzinger <kylelholzinger@gmail.com>"
 
+RUN adduser -u 9000 -D app
+
 WORKDIR /usr/src/app
 
-COPY engine.json ./
+COPY engine.json package.json yarn.lock ./
 COPY ./bin/ ./bin/
 
 RUN npm install --global yarn && \
   apk --update add git jq && \
-  bin/get-tslint-rules "$(bin/version tslint)" && \
-  cat engine.json | jq ".version = \"$(bin/version tslint)\"" > /tmp/engine.json && \
+  yarn install && \
+  jq <engine.json ".version = \"$(bin/version tslint)\"" > /tmp/engine.json && \
+  mv {/tmp/,}engine.json && \
+  bin/get-tslint-rules && \
+  chown -R app:app . && \
   apk del --purge git jq && \
+  rm -rf /var/cache/apk/* /tmp/* ~/.npm && \
   npm uninstall --global yarn
 
-RUN adduser -u 9000 -D app
+USER app
 
-COPY . /usr/src/app
-RUN npm install --global yarn && \
-  chown -R app:app ./ && \
-  yarn install && \
-  npm uninstall --global yarn && \
-  mv /tmp/engine.json ./
+COPY . ./
 RUN npm run build
 
-USER app
 VOLUME /code
 WORKDIR /code
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: image
+
+IMAGE_NAME ?= codeclimate/codeclimate-tslint
+
+image:
+	docker build --rm -t \
+		$(IMAGE_NAME) .

--- a/engine.json
+++ b/engine.json
@@ -7,5 +7,5 @@
   },
   "languages" : ["TypeScript"],
   "version": "51e260eb5c8842431dad261fa70a700382cf9e60",
-  "spec_version": "0.2.3"
+  "spec_version": "0.3.1"
 }


### PR DESCRIPTION
There was a possibility to improperly build an image that would contain docs from mismatched TSLint version. This could result in error caused by the engine being unable to find issue descriptions. This appears to be the reason current beta channel of this engine is broken — it contains docs for TSLint 5.0 while 5.1 is used in code.

This Dockerfile eliminates the issue and adds a few clean up steps to bring the image size a little down.

Fixes #31 