### PR TITLE
Suggestion: add ignore_warnings option

### DIFF
--- a/src/codeclimateDefinitions.ts
+++ b/src/codeclimateDefinitions.ts
@@ -8,6 +8,7 @@ export interface IConfig {
   channel?: string;
   include_paths: string[];
   config?: string;
+  ignore_warnings?: boolean;
 }
 
 export interface IIssue {

--- a/src/tsLinter.ts
+++ b/src/tsLinter.ts
@@ -57,6 +57,15 @@ export class TsLinter {
 
     linter.lint(fileName, contents, this.configurationFile);
 
+    if (this.option.codeClimateConfig.ignore_warnings) {
+      return rx.Observable
+        .from(linter.getResult().failures)
+        .filter((failure) => failure.getRuleSeverity() !== 'warning')
+        .map(this.issueConverter.convert)
+        .catch((e: any) => rx.Observable.of(Utils.createIssueFromError(e)))
+        ;
+    }
+
     return rx.Observable
       .from(linter.getResult().failures)
       .map(this.issueConverter.convert)


### PR DESCRIPTION
codeclimate-tslint works well for my project, but tslint warnings are converted to `minor`-level issues in Codeclimate, which leads to GitHub status check failures for lint runs that would exit 0 when using the tslint CLI.

I don't think a lint run that emits only warnings should be considered a fail, so here is an idea for an `ignore_warnings` option like in [codeclimate-eslint](https://github.com/codeclimate/codeclimate-eslint/blob/master/README.md#ignore_warnings).

An alternative (and probably better) solution would be to create `info`-level issues on Codeclimate from tslint warnings.