### PR TITLE
Adding support for running prettier with tslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,11 +69,14 @@
     "codelyzer": "^4.0.2",
     "handlebars": "^4.0.6",
     "lodash": "^4.17.4",
+    "prettier": "^1.10.2",
     "rxjs": "^5.3.0",
     "tslint": "5.9.1",
     "tslint-config-airbnb": "5.4.2",
+    "tslint-config-prettier": "^1.6.0",
     "tslint-config-standard": "7.0.0",
     "tslint-eslint-rules": "4.1.1",
+    "tslint-plugin-prettier": "^1.3.0",
     "tslint-react": "3.4.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,12 +13,14 @@ const rulesPath: string = '../docs/tslint-rules';
 
 const tslintEslintRulesPath = 'node_modules/tslint-eslint-rules/dist/rules';
 const codelyzerRulesPath = 'node_modules/codelyzer';
+const prettierRulesPath = 'node_modules/tslint-plugin-prettier/rules';
 
 const codeClimateConfig: IConfig = loadCodeClimateConfig(configPath);
 const ruleLoader = new RuleLoader(linterPath);
 const rules: IRuleMetadata[] = (require(rulesPath) as IRuleMetadata[])
   .concat(ruleLoader.loadRules(tslintEslintRulesPath))
   .concat(ruleLoader.loadRules(codelyzerRulesPath))
+  .concat(ruleLoader.loadRules(prettierRulesPath))
 ;
 
 function loadCodeClimateConfig(file: string): IConfig {

--- a/yarn.lock
+++ b/yarn.lock
@@ -475,6 +475,13 @@ escodegen@1.8.x:
   optionalDependencies:
     source-map "~0.2.0"
 
+eslint-plugin-prettier@^2.2.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.5.0.tgz#39a91dd7528eaf19cd42c0ee3f2c1f684606a05f"
+  dependencies:
+    fast-diff "^1.1.1"
+    jest-docblock "^21.0.0"
+
 esprima@2.7.x, esprima@^2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
@@ -522,6 +529,10 @@ extsprintf@1.3.0:
 extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
+
+fast-diff@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.2.tgz#4b62c42b8e03de3f848460b639079920695d0154"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -741,6 +752,10 @@ istanbul@0.4.5, istanbul@^0.4.5:
     supports-color "^3.1.0"
     which "^1.1.1"
     wordwrap "^1.0.0"
+
+jest-docblock@^21.0.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
 
 js-tokens@^3.0.2:
   version "3.0.2"
@@ -1066,6 +1081,10 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
 
+prettier@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.10.2.tgz#1af8356d1842276a99a5b5529c82dd9e9ad3cc93"
+
 process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
@@ -1340,6 +1359,10 @@ tslint-config-airbnb@5.4.2:
     tslint-eslint-rules "^4.1.1"
     tslint-microsoft-contrib "~5.0.1"
 
+tslint-config-prettier@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.6.0.tgz#fec1ee8fb07e8f033c63fed6b135af997f31962a"
+
 tslint-config-standard@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/tslint-config-standard/-/tslint-config-standard-7.0.0.tgz#47bbf25578ed2212456f892d51e1abe884a29f15"
@@ -1366,6 +1389,13 @@ tslint-microsoft-contrib@~5.0.1:
   resolved "https://registry.yarnpkg.com/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.0.2.tgz#ecc2a797f777a12f0066944cec0c81a9e7c59ee9"
   dependencies:
     tsutils "^2.12.1"
+
+tslint-plugin-prettier@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/tslint-plugin-prettier/-/tslint-plugin-prettier-1.3.0.tgz#7eb65d19ea786a859501a42491b78c5de2031a3f"
+  dependencies:
+    eslint-plugin-prettier "^2.2.0"
+    tslib "^1.7.1"
 
 tslint-react@3.4.0:
   version "3.4.0"


### PR DESCRIPTION
My team has been using tslint with codeclimate for a while and we want to add prettier to our project, but are running into an issue due to lack of prettier support.

This PR also addresses the request in this issue: https://github.com/tkqubo/codeclimate-tslint/issues/30

- Adds [tslint-config-prettier](https://github.com/alexjoverm/tslint-config-prettier) to allow playing nicely with [prettier](https://github.com/prettier/prettier).
- Adds [tslint-plugin-prettier](https://github.com/ikatyang/tslint-plugin-prettier) which adds a new `prettier` rule to run and report prettier errors through tslint.  This rule is not set by default so won't affect any users not using prettier.
- Adds [prettier](https://github.com/prettier/prettier) as a dependency to support `tslint-plugin-prettier`.

To use `tslint-config-prettier`:
Extend `"tslint-config-prettier"` is tslint.json.

To use `tslint-plugin-prettier`:
Add `"tslint-plugin-prettier"` to `rulesDirectory` in tslint.json
Add `prettier: true` to `rules` in tslint.json