### PR TITLE
fix: rulesDirectory could refer to the existent directories

### DIFF
--- a/src/configFileNormalizer.ts
+++ b/src/configFileNormalizer.ts
@@ -1,0 +1,31 @@
+'use strict';
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {RawConfigFile} from 'tslint/lib/configuration';
+
+/**
+ * Normalizes tsconfg.json file.
+ * Currently doing these stuffs.
+ * <ul>
+ *   <li>Redirect rule directories if they are not found on the original path but are defined in the tslint base path</li>
+ * </ul>
+ */
+export class ConfigFileNormalizer {
+  normalize(inPath: string, outPath: string, altRulesDirectory: string) {
+    const rawConfig: RawConfigFile = JSON.parse(fs.readFileSync(inPath).toString('UTF-8'));
+    if (typeof rawConfig.rulesDirectory === 'string') {
+      rawConfig.rulesDirectory = this.normalizeRulesDirectoryPath(rawConfig.rulesDirectory, altRulesDirectory);
+    } else if (rawConfig.rulesDirectory !== undefined) {
+      rawConfig.rulesDirectory = rawConfig.rulesDirectory.map(dir => this.normalizeRulesDirectoryPath(dir, altRulesDirectory));
+    }
+    fs.writeFileSync(outPath, JSON.stringify(rawConfig), 'UTF-8');
+  }
+
+  normalizeRulesDirectoryPath(dirPath: string, altRulesDirectory: string): string {
+    if (!fs.existsSync(dirPath) && fs.existsSync(path.join(altRulesDirectory, dirPath))) {
+      return path.join(altRulesDirectory, dirPath);
+    }
+    return dirPath;
+  }
+}

--- a/src/test/tsLinter.spec.ts
+++ b/src/test/tsLinter.spec.ts
@@ -17,7 +17,7 @@ describe('TsLinter', () => {
   const linterPath: string = './';
   const targetPath: string = '/base/path/';
   const templateFile = path.join(linterPath, ContentRenderer.templateFileName);
-  describe('.tsLintFilePath', () => {
+  describe('.originalConfigPath', () => {
     const rules: IRuleMetadata[] = [];
     it('returns the specified file on the base path', done => {
       // Given
@@ -28,7 +28,7 @@ describe('TsLinter', () => {
       // When
       const tsLinter = new TsLinter({targetPath, linterPath, codeClimateConfig, rules});
       // Then
-      assert.equal(tsLinter.tsLintFilePath, expected);
+      assert.equal(tsLinter.originalConfigPath, expected);
       mock.restore();
       done();
     });
@@ -40,7 +40,7 @@ describe('TsLinter', () => {
       // When
       const tsLinter = new TsLinter({targetPath, linterPath, codeClimateConfig, rules});
       // Then
-      assert.equal(tsLinter.tsLintFilePath, expected);
+      assert.equal(tsLinter.originalConfigPath, expected);
       mock.restore();
       done();
     });
@@ -52,7 +52,7 @@ describe('TsLinter', () => {
       // When
       const tsLinter = new TsLinter({targetPath, linterPath, codeClimateConfig, rules});
       // Then
-      assert.equal(tsLinter.tsLintFilePath, expected);
+      assert.equal(tsLinter.originalConfigPath, expected);
       mock.restore();
       done();
     });
@@ -64,7 +64,7 @@ describe('TsLinter', () => {
       // When
       const tsLinter = new TsLinter({targetPath, linterPath, codeClimateConfig, rules});
       // Then
-      assert.equal(tsLinter.tsLintFilePath, expected);
+      assert.equal(tsLinter.originalConfigPath, expected);
       mock.restore();
       done();
     });

--- a/src/tsLinter.ts
+++ b/src/tsLinter.ts
@@ -13,6 +13,7 @@ import {ITsLinterOption} from './tsLinterOption';
 import Utils from './utils';
 import {RuleFailure} from 'tslint/lib/language/rule/rule';
 import autobind from 'autobind-decorator';
+import {ConfigFileNormalizer} from './configFileNormalizer';
 
 export class TsLinter {
   static defaultTsLintFileName: string = 'tslint.json';
@@ -21,18 +22,21 @@ export class TsLinter {
     fix: false,
     formatter: 'json'
   };
-  tsLintFilePath: string;
+  originalConfigPath: string;
+  normalizedConfigPath: string;
   protected readonly fileMatcher: FileMatcher;
   protected readonly issueConverter: IssueConverter;
   protected readonly configurationFile: IConfigurationFile;
 
   constructor(
-    public option: ITsLinterOption
+    public option: ITsLinterOption, configFileNormalizer: ConfigFileNormalizer = new ConfigFileNormalizer()
   ) {
-    this.tsLintFilePath = this.getTsLintFilePath();
     this.fileMatcher = new FileMatcher(option.targetPath, ['.ts', '.tsx']);
     this.issueConverter = new IssueConverter(option);
-    this.configurationFile = Configuration.findConfiguration(this.tsLintFilePath, '').results;
+    this.originalConfigPath = this.getTsLintFilePath();
+    this.normalizedConfigPath = path.join(this.option.linterPath, `temp_${TsLinter.defaultTsLintFileName}`);
+    configFileNormalizer.normalize(this.originalConfigPath, this.normalizedConfigPath, option.linterPath);
+    this.configurationFile = Configuration.findConfiguration(this.normalizedConfigPath, '').results;
   }
 
   @autobind


### PR DESCRIPTION
Make tslint reference `node_modules` in the engine directory.  In doing this, codeclimate-tslint can use rules such as [codelyzer](https://github.com/mgechev/codelyzer) and [tslint-eslint-rules](https://github.com/buzinas/tslint-eslint-rules).