### PR TITLE
fix: handle file not found error on CodeClimate Engine

### DIFF
--- a/src/test/issueConverter.spec.ts
+++ b/src/test/issueConverter.spec.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('power-assert');
+import {fail, ok} from 'power-assert';
 import * as sinon from 'sinon';
 import * as ts from 'typescript';
 import {IRuleMetadata, RuleFailure} from 'tslint';
@@ -8,9 +8,10 @@ import {IssueConverter} from '../issueConverter';
 import * as CodeClimate from '../codeclimateDefinitions';
 import {IConfig} from '../codeclimateDefinitions';
 
+const assert = require('power-assert');
+
 describe('IssueConverter', () => {
-  it('.convert(failure: RuleFailure)', () => {
-    // given
+  describe('.convert(failure: RuleFailure)', () => {
     const linterPath: string = './';
     const targetPath: string = '/base/path/';
     const codeClimateConfig: IConfig = {include_paths: []};
@@ -27,30 +28,45 @@ describe('IssueConverter', () => {
         'foo', 'bar'
       ]
     };
-    const converter = new IssueConverter({ targetPath, linterPath, codeClimateConfig, rules: [ruleMetadata] });
+    const converter = new IssueConverter({targetPath, linterPath, codeClimateConfig, rules: [ruleMetadata]});
     const sourceFile = sinon.mock({}) as any as ts.SourceFile;
     const sourcePath = 'path/target-source-file.ts';
     sourceFile.fileName = `${targetPath}${sourcePath}`;
     sourceFile.getLineAndCharacterOfPosition = (pos: number) => {
-        return pos === 1 ? { line: 2, character: 30 } : { line: 8, character: 24 };
+      return pos === 1 ? {line: 2, character: 30} : {line: 8, character: 24};
     };
-    const ruleFailure = new RuleFailure(sourceFile, 1, 2, failure, ruleName);
-    // when
-    const actual = converter.convert(ruleFailure);
-    // then
-    assert(actual !== null && actual !== undefined);
-    assert(actual.type === 'issue');
-    assert(actual.categories.length === 1);
-    assert(actual.categories[0] === 'Style');
-    assert(actual.check_name === ruleName);
-    assert(actual.description === failure);
-    const location = actual.location as CodeClimate.IPositionLocation;
-    const begin = location.positions.begin as CodeClimate.ILineColumnPosition ;
-    const end = location.positions.end as CodeClimate.ILineColumnPosition ;
-    assert(location.path === sourcePath);
-    assert(begin.line === 3);
-    assert(begin.column === 31);
-    assert(end.line === 9);
-    assert(end.column === 25);
+    it('converts RuleFailure object properly', () => {
+      // given
+      const ruleFailure = new RuleFailure(sourceFile, 1, 2, failure, ruleName);
+      // when
+      const actual = converter.convert(ruleFailure);
+      // then
+      assert(actual !== null && actual !== undefined);
+      assert(actual.type === 'issue');
+      assert(actual.categories.length === 1);
+      assert(actual.categories[0] === 'Style');
+      assert(actual.check_name === ruleName);
+      assert(actual.description === failure);
+      const location = actual.location as CodeClimate.IPositionLocation;
+      const begin = location.positions.begin as CodeClimate.ILineColumnPosition;
+      const end = location.positions.end as CodeClimate.ILineColumnPosition;
+      assert(location.path === sourcePath);
+      assert(begin.line === 3);
+      assert(begin.column === 31);
+      assert(end.line === 9);
+      assert(end.column === 25);
+    });
+    it('throws an error when rule name is not found', () => {
+      // given
+      const ruleFailure = new RuleFailure(sourceFile, 1, 2, failure, 'non-existent');
+      try {
+        // when
+        converter.convert(ruleFailure);
+        fail();
+      } catch (e) {
+        // then
+        ok('should fail');
+      }
+    });
   });
 });

--- a/src/test/utils.spec.ts
+++ b/src/test/utils.spec.ts
@@ -1,6 +1,5 @@
 'use strict';
 
-import Linter = require('tslint/lib/linter');
 const mock = require('mock-fs');
 const assert = require('power-assert');
 import * as CodeClimate from '../codeclimateDefinitions';
@@ -9,16 +8,17 @@ import Utils from '../utils';
 describe('Utils', () => {
   describe('createEmptyRuleMetadata(ruleName: string)', () => {
     it('creates correct instance', done => {
-      let name = 'rule-name';
-      let actual = Utils.createEmptyRuleMetadata(name);
+      const name = 'rule-name';
+      const actual = Utils.createEmptyRuleMetadata(name);
       assert.equal(actual.ruleName, name);
       done();
     });
   });
   describe('createIssueFromError(e: Error)', () => {
     it('creates correct instance', done => {
-      let e = new Error('error message');
-      let actual = Utils.createIssueFromError(e);
+      const path = 'some path';
+      const e = new Error('error message');
+      const actual = Utils.createIssueFromError(e, path);
       assert.equal(actual.description, `${e.name}: ${e.message}\n${e.stack}`);
       assert.equal(actual.type, CodeClimate.issueTypes.Issue);
       done();

--- a/src/tsLinter.ts
+++ b/src/tsLinter.ts
@@ -23,9 +23,9 @@ export class TsLinter {
     formatter: 'json'
   };
   originalConfigPath: string;
-  protected readonly fileMatcher: FileMatcher;
-  protected readonly issueConverter: IssueConverter;
-  protected readonly configurationFile: IConfigurationFile;
+  fileMatcher: FileMatcher;
+  issueConverter: IssueConverter;
+  configurationFile: IConfigurationFile;
 
   constructor(
     public option: ITsLinterOption, configFileNormalizer: ConfigFileNormalizer = new ConfigFileNormalizer(option.linterPath)
@@ -69,8 +69,14 @@ export class TsLinter {
     }
     return observable
       .map(this.issueConverter.convert)
-      .catch((e: any) => rx.Observable.of(Utils.createIssueFromError(e)))
+      .catch((e: any) => rx.Observable.of(Utils.createIssueFromError(e, this.getRelativeFilePath(fileName))))
       ;
+  }
+
+  getRelativeFilePath(fileName: string): string {
+    const dirname = path.dirname(fileName);
+    const basename = path.basename(fileName);
+    return path.join(path.relative(this.option.targetPath, dirname), basename);
   }
 
   @autobind

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,7 +15,7 @@ class Utils {
     };
   }
 
-  createIssueFromError(e: Error): CodeClimate.IIssue {
+  createIssueFromError(e: Error, path: string): CodeClimate.IIssue {
     return {
       type: CodeClimate.issueTypes.Issue,
       check_name: '(runtime error)',
@@ -23,7 +23,7 @@ class Utils {
       categories: ['Bug Risk'],
       remediation_points: 50000,
       location: {
-        path: '',
+        path,
         positions: {
           begin: { line: 0, column: 0 },
           end: { line: 0, column: 0 }


### PR DESCRIPTION
When conversion from a tslint issue into a CodeClimate issue fails, codeclimate-tslint fails, too.  This PR will fix it.  Hopefully the fix for https://github.com/tkqubo/codeclimate-tslint/issues/38