### PR TITLE
Add @kushki/tslint package

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "zone.js": "^0.8.20"
   },
   "dependencies": {
+    "@kushki/tslint": "^5.0.2",
     "@types/handlebars": "^4.0.32",
     "codelyzer": "^4.0.2",
     "handlebars": "^4.0.6",
@@ -71,8 +72,7 @@
     "tslint-no-circular-imports": "^0.6.1",
     "tslint-no-unused-expression-chai": "^0.1.4",
     "tslint-plugin-prettier": "^1.3.0",
-    "tslint-react": "3.4.0",
-    "@kushki/tslint"
+    "tslint-react": "3.4.0"  
   },
   "nyc": {
     "include": ["src/**/*.ts"],

--- a/package.json
+++ b/package.json
@@ -20,7 +20,12 @@
     "type": "git",
     "url": "git+https://github.com/tkqubo/codeclimate-tslint.git"
   },
-  "keywords": ["TypeScript", "tslint", "codeclimate", "Code Climate"],
+  "keywords": [
+    "TypeScript",
+    "tslint",
+    "codeclimate",
+    "Code Climate"
+  ],
   "author": "tkqubo",
   "license": "MIT",
   "bugs": {
@@ -56,6 +61,7 @@
     "zone.js": "^0.8.20"
   },
   "dependencies": {
+    "@kushki/tslint": "^5.0.2",
     "@types/handlebars": "^4.0.32",
     "codelyzer": "^4.0.2",
     "handlebars": "^4.0.6",
@@ -71,15 +77,26 @@
     "tslint-no-circular-imports": "^0.6.1",
     "tslint-no-unused-expression-chai": "^0.1.4",
     "tslint-plugin-prettier": "^1.3.0",
-    "tslint-react": "3.4.0",
-    "@kushki/tslint"
+    "tslint-react": "3.4.0"
   },
   "nyc": {
-    "include": ["src/**/*.ts"],
-    "exclude": ["src/**/*.spec.ts"],
-    "extension": [".ts"],
-    "require": ["ts-node/register"],
-    "reporter": ["text", "html", "lcov"],
+    "include": [
+      "src/**/*.ts"
+    ],
+    "exclude": [
+      "src/**/*.spec.ts"
+    ],
+    "extension": [
+      ".ts"
+    ],
+    "require": [
+      "ts-node/register"
+    ],
+    "reporter": [
+      "text",
+      "html",
+      "lcov"
+    ],
     "sourceMap": true,
     "instrument": true
   }

--- a/package.json
+++ b/package.json
@@ -20,12 +20,7 @@
     "type": "git",
     "url": "git+https://github.com/tkqubo/codeclimate-tslint.git"
   },
-  "keywords": [
-    "TypeScript",
-    "tslint",
-    "codeclimate",
-    "Code Climate"
-  ],
+  "keywords": ["TypeScript", "tslint", "codeclimate", "Code Climate"],
   "author": "tkqubo",
   "license": "MIT",
   "bugs": {
@@ -61,7 +56,6 @@
     "zone.js": "^0.8.20"
   },
   "dependencies": {
-    "@kushki/tslint": "^5.0.2",
     "@types/handlebars": "^4.0.32",
     "codelyzer": "^4.0.2",
     "handlebars": "^4.0.6",
@@ -77,26 +71,15 @@
     "tslint-no-circular-imports": "^0.6.1",
     "tslint-no-unused-expression-chai": "^0.1.4",
     "tslint-plugin-prettier": "^1.3.0",
-    "tslint-react": "3.4.0"
+    "tslint-react": "3.4.0",
+    "@kushki/tslint"
   },
   "nyc": {
-    "include": [
-      "src/**/*.ts"
-    ],
-    "exclude": [
-      "src/**/*.spec.ts"
-    ],
-    "extension": [
-      ".ts"
-    ],
-    "require": [
-      "ts-node/register"
-    ],
-    "reporter": [
-      "text",
-      "html",
-      "lcov"
-    ],
+    "include": ["src/**/*.ts"],
+    "exclude": ["src/**/*.spec.ts"],
+    "extension": [".ts"],
+    "require": ["ts-node/register"],
+    "reporter": ["text", "html", "lcov"],
     "sourceMap": true,
     "instrument": true
   }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "tslint-no-circular-imports": "^0.6.1",
     "tslint-no-unused-expression-chai": "^0.1.4",
     "tslint-plugin-prettier": "^1.3.0",
-    "tslint-react": "3.4.0"  
+    "tslint-react": "3.4.0"
   },
   "nyc": {
     "include": ["src/**/*.ts"],

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "tslint-no-circular-imports": "^0.6.1",
     "tslint-no-unused-expression-chai": "^0.1.4",
     "tslint-plugin-prettier": "^1.3.0",
-    "tslint-react": "3.4.0"
+    "tslint-react": "3.4.0",
+    "@kushki/tslint"
   },
   "nyc": {
     "include": ["src/**/*.ts"],


### PR DESCRIPTION
Add @kushki/tslint package so it can be included in custom tslint configs.

A brief resume of Kushki: We are the first payment gateway serverless (https://www.kushkipagos.com) and love to write clean code so we create our custom tslint that is the merge of many popular libraries:
- rxjs-tslint
- rxjs-tslint-rules
- tslint-config-prettier
- tslint-consistent-codestyle
- tslint-eslint-rules
- tslint-microsoft-contrib
- tslint-no-unused-expression-chai
- tslint-sonarts
- vrsource-tslint-rules

All the enabled rules are oriented to reactive programming [(https://rxjs.dev/)](https://rxjs.dev/). Right now we are integrating with Code Climate all our current pipeline and the only missing piece is move the tslint scan to it.