### PR TITLE
Accept JS config files

### DIFF
--- a/src/test/mockConfig.js
+++ b/src/test/mockConfig.js
@@ -1,0 +1,1 @@
+module.exports = { key1: "value", key2: 123, key4: false, key5: null };

--- a/src/test/tsConfigNormalizer.spec.ts
+++ b/src/test/tsConfigNormalizer.spec.ts
@@ -70,6 +70,16 @@ describe('tsConfigNormalizer', () => {
       // Then
       assert.deepStrictEqual(actual, expected);
     });
+
+    it('should load JS', async () => {
+      // Given
+      const fileName = path.join(__dirname, 'mockConfig.js');
+      const expected: any = {key1: 'value', key2: 123, key4: false, key5: null};
+      // When
+      const actual = load(fileName);
+      // Then
+      assert.deepStrictEqual(actual, expected);
+    });
   });
   describe('save', () => {
     it('should save JSON', async () => {

--- a/src/tsConfigNormalizer.ts
+++ b/src/tsConfigNormalizer.ts
@@ -25,9 +25,7 @@ export function normalizeTsConfig(input: string, altBase: string): string {
   const config = load(input);
   config.rulesDirectory = resolveRulesDirectory(config.rulesDirectory, altBase);
   const output = getTemporaryFileName();
-  if (!isJSFile(input)) {
-    save(config, output);
-  }
+  save(config, output);
   return output;
 }
 

--- a/src/tsConfigNormalizer.ts
+++ b/src/tsConfigNormalizer.ts
@@ -25,11 +25,21 @@ export function normalizeTsConfig(input: string, altBase: string): string {
   const config = load(input);
   config.rulesDirectory = resolveRulesDirectory(config.rulesDirectory, altBase);
   const output = getTemporaryFileName();
-  save(config, output);
+  if (!isJSFile(input)) {
+    save(config, output);
+  }
   return output;
 }
 
+function isJSFile(file: string) {
+  return file.endsWith('.js');
+}
+
 export function load(file: string): RawConfigFile {
+  if (isJSFile(file)) {
+    return require(file);
+  }
+
   return JSON.parse(stripJsonComments(fs.readFileSync(file).toString('UTF-8')));
 }
 


### PR DESCRIPTION
Similar to TSLint, the plugin should allow JS configuration files. I'm not sure what the security implications of this approach are, but I'm interested in seeing what you think.

https://github.com/palantir/tslint/blob/d9e20beeb6c76e6321ebafd08df8f6fae9b0eb29/src/configuration.ts#L254

I'm hoping that having JS configs will make extending easier...

Related issues:
- https://github.com/tkqubo/codeclimate-tslint/issues/51